### PR TITLE
Misc fixes and new linked-loci test

### DIFF
--- a/snpio/filtering/filtering_methods.py
+++ b/snpio/filtering/filtering_methods.py
@@ -420,13 +420,16 @@ class FilteringMethods:
             )
             return self.nremover
 
-        if self.genotype_data.filetype != "vcf":
-            msg = f"Only 'vcf' file type is supported for filtering linked loci, but got {self.genotype_data.filetype}"
+        if self.nremover.genotype_data.filetype != "vcf":
+            msg = (
+                "Only 'vcf' file type is supported for filtering linked loci, "
+                f"but got {self.nremover.genotype_data.filetype}"
+            )
             self.logger.error(msg)
             raise AlignmentFormatError(msg)
 
         # Construct the path to the HDF5 file
-        hdf5_path = self.genotype_data.vcf_attributes_fn
+        hdf5_path = self.nremover.genotype_data.vcf_attributes_fn
 
         # Check if the HDF5 file exists
         if not Path(hdf5_path).is_file():
@@ -481,6 +484,8 @@ class FilteringMethods:
             return self.nremover
 
         # Update the loci indices with the mask
+        if not hasattr(self.nremover, "current_thresholds"):
+            self.nremover.current_thresholds = (None, None, None, None)
         self.nremover._update_loci_indices(mask, inspect.stack()[0][3])
 
         return self.nremover

--- a/snpio/filtering/nremover2.py
+++ b/snpio/filtering/nremover2.py
@@ -111,9 +111,9 @@ class NRemover2:
 
         prefix (str): The prefix for the output files.
 
-        popmap (Dict[str, str | int): A dictionary mapping sample IDs to population names.
+        popmap (Dict[str, str | int]): A dictionary mapping sample IDs to population names.
 
-        popmap_inverse (Dict[str | int], List[str]]): A dictionary mapping population names to lists of sample IDs.
+        popmap_inverse (Dict[str | int, List[str]]): A dictionary mapping population names to lists of sample IDs.
 
         sample_indices (np.ndarray): A boolean array indicating which samples to keep.
 

--- a/snpio/read_input/genotype_data.py
+++ b/snpio/read_input/genotype_data.py
@@ -1478,14 +1478,14 @@ class GenotypeData(BaseGenotypeData):
         if isinstance(value, list):
             value = np.array(value)
         if not value.dtype is np.dtype(bool):
-            msg = f"Attempt to set 'sample_indices' to an unexpected np.dtype. Expected 'bool', but got: {value.dtype}"
+            msg = f"Attempt to set 'loci_indices' to an unexpected np.dtype. Expected 'bool', but got: {value.dtype}"
             self.logger.error(msg)
             raise TypeError(msg)
         self._loci_indices = value
 
     @property
     def sample_indices(self) -> np.ndarray:
-        """Row indices for retained samples in alignemnt.
+        """Row indices for retained samples in alignment.
 
         Returns:
             np.ndarray: Boolean array of sample indices, with True for retained samples and False for excluded samples.

--- a/tests/test_nremover2.py
+++ b/tests/test_nremover2.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import numpy as np
 from snpio import NRemover2, VCFReader
 
 
@@ -207,6 +208,12 @@ class TestNRemover2(unittest.TestCase):
         ]
         expected_indices = [0, 1, 3]  # Locus 2 monomorphic; locus 4 multiallelic
         self.assertEqual(retained_indices, expected_indices)
+
+    def test_filter_linked(self):
+        np.random.seed(0)
+        filtered_data = self.nrm.filter_linked().resolve()
+        self.assertEqual(filtered_data.num_snps, 2)
+        self.assertEqual(np.count_nonzero(filtered_data.loci_indices), 2)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Summary
- fix typo in sample_indices docstring
- clarify error message in `loci_indices` setter
- repair NRemover2 docstring example
- fix `filter_linked` access to genotype data
- initialise `current_thresholds` when needed
- add test for `filter_linked`

## Testing
- `pytest tests/test_nremover2.py::TestNRemover2::test_filter_linked -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68559b5b3a788320aff784bd09d8435e