### PR TITLE
ci: Enforce clean publisher validation

### DIFF
--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -4,6 +4,12 @@ name: Publish Conda Package to btmartin721/snpio
 
 on:
   workflow_dispatch:
+    inputs:
+      upload_packages:
+        description: 'Upload successful builds to Anaconda.org.'
+        required: false
+        type: boolean
+        default: true
   push:
     tags:
       - "v*.*.*"
@@ -22,15 +28,16 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
           activate-environment: snpio-build
-          channels: conda-forge,bioconda,defaults
+          channels: conda-forge,bioconda
           channel-priority: strict
+          conda-remove-defaults: true
           auto-update-conda: true
-          auto-activate-base: false
+          auto-activate: false
           environment-file: etc/environment.yml
 
       - name: Build Conda package
@@ -38,12 +45,14 @@ jobs:
         env:
           CI: "1"
         run: |
-          conda install --yes -c conda-forge conda-build anaconda-client
+          conda install --yes --override-channels -c conda-forge \
+            conda-build anaconda-client
           conda-build recipe/ \
             --output-folder conda_build_artifacts \
             --python ${{ matrix.python-version }} --no-test
 
       - name: Upload to Anaconda.org
+        if: github.event_name == 'push' || inputs.upload_packages
         shell: bash -el {0}
         env:
           ANACONDA_API_TOKEN: ${{ secrets.SNPIO_UPLOAD_TOKEN }}

--- a/.github/workflows/pypi-docker-publish.yml
+++ b/.github/workflows/pypi-docker-publish.yml
@@ -11,6 +11,16 @@ name: Publish to TestPyPI, PyPI, and DockerHub
 
 on:
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version to build when dispatching from a branch (e.g., 1.7.0).'
+        required: false
+        default: ''
+      publish_python:
+        description: 'Upload the distributions to TestPyPI and PyPI.'
+        required: false
+        type: boolean
+        default: true
   push:
     tags:
       - 'v*.*.*'  # Only run on semantic version tag pushes
@@ -26,33 +36,43 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.12'        
+          python-version: '3.12'
 
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          python -m pip install build twine
 
       - name: Install version file dependencies
-        run: pip install tomli-w pyyaml
+        run: python -m pip install tomli-w pyyaml
 
       - name: Extract version from tag
         id: extract_version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          if [[ -n "$RELEASE_VERSION" ]]; then
+            VERSION="$RELEASE_VERSION"
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must use MAJOR.MINOR.PATCH format."
+            exit 1
+          fi
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-  
+
       - name: Update version files
-        run: python scripts/update_versions.py $VERSION
-  
+        run: python scripts/update_versions.py "$VERSION"
+
       - name: Clean dist directory
         run: rm -rf dist/
-  
+
       - name: Build package
         run: python -m build
 
       - name: Publish to TestPyPI
+        if: github.event_name == 'push' || inputs.publish_python
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -61,6 +81,7 @@ jobs:
           echo "TestPyPI upload complete."
 
       - name: Publish to PyPI
+        if: github.event_name == 'push' || inputs.publish_python
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.SNPIO_API_TOKEN2_PYPI }}
@@ -74,16 +95,16 @@ jobs:
       ##########################################
 
       - name: Set up QEMU for cross-platform builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        id: buildx
+        uses: docker/setup-buildx-action@v4
         with:
-          install: true
           driver-opts: network=host
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_BTMARTIN721 }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM continuumio/miniconda3
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    CONDA_ENV=snpioenv
+    CONDA_ENV=snpioenv \
+    CONDA_NO_PLUGINS=true \
+    PIP_ROOT_USER_ACTION=ignore
 
 # Install system-level dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -20,24 +22,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     libncurses-dev \
     libhdf5-dev \
+    xz-utils \
     ca-certificates \
     unzip \
     procps \
+    zsh \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a new Conda environment and install dependencies
-RUN conda create -y -n $CONDA_ENV -c conda-forge -c btmartin721 \
+RUN conda create --yes --solver classic --override-channels \
+    --name "$CONDA_ENV" -c conda-forge -c btmartin721 \
     python=3.12 \
     numpy=2.2.6 \
     pandas=2.2.3 \
     pip && \
     conda clean -afy && \
-    conda init bash && \
     echo "conda activate $CONDA_ENV" > ~/.bashrc
 
-ENV PATH /opt/conda/envs/$CONDA_ENV/bin:$PATH
+ENV PATH=/opt/conda/envs/$CONDA_ENV/bin:$PATH
 
-RUN conda run -n $CONDA_ENV pip install --no-cache-dir \
+RUN conda run -n "$CONDA_ENV" python -m pip install --no-cache-dir \
     snpio \
     pytest \
     jupyterlab && \
@@ -45,7 +49,9 @@ RUN conda run -n $CONDA_ENV pip install --no-cache-dir \
 
 # Create a non-root user and set home directory
 RUN useradd -ms /bin/bash snpiouser && \
-    mkdir -p /home/snpiouser/.config/matplotlib /app/results /app/docs /app/example_data && \
+    mkdir -p /home/snpiouser/.cache/numba \
+    /home/snpiouser/.config/matplotlib \
+    /app/results /app/docs /app/example_data && \
     chown -R snpiouser:snpiouser /app /home/snpiouser
 
 # Set working directory
@@ -53,8 +59,10 @@ WORKDIR /app
 
 # Copy application files with correct permissions
 COPY --chown=snpiouser:snpiouser tests/ tests/
+COPY --chown=snpiouser:snpiouser scripts/ scripts/
 COPY --chown=snpiouser:snpiouser scripts_and_notebooks/ scripts_and_notebooks/
 COPY --chown=snpiouser:snpiouser snpio/example_data/ example_data/
+COPY --chown=snpiouser:snpiouser multiqc_config.yml pyproject.toml ./
 COPY --chown=snpiouser:snpiouser README.md docs/README.md
 COPY --chown=snpiouser:snpiouser scripts_and_notebooks/.bashrc_snpio /home/snpiouser/.bashrc
 
@@ -62,10 +70,11 @@ COPY --chown=snpiouser:snpiouser scripts_and_notebooks/.bashrc_snpio /home/snpio
 USER snpiouser
 ENV HOME=/home/snpiouser
 ENV MPLCONFIGDIR=$HOME/.config/matplotlib
-RUN chmod -R u+w $HOME/.config/matplotlib
+ENV NUMBA_CACHE_DIR=$HOME/.cache/numba
+RUN chmod -R u+w "$MPLCONFIGDIR" "$NUMBA_CACHE_DIR"
 
-# Run tests (non-blocking; allows image to build even if tests fail)
-RUN conda run -n $CONDA_ENV pytest tests/ || echo "Tests failed during build; continuing..."
+# Validate the installed release before publishing the image.
+RUN conda run -n "$CONDA_ENV" python -m pytest -q
 
 # Default container command
 CMD ["bash"]

--- a/etc/environment.yml
+++ b/etc/environment.yml
@@ -2,9 +2,8 @@ name: snpio-build
 channels:
   - conda-forge
   - bioconda
-  - defaults
 
-channel_priority: flexible
+channel_priority: strict
 
 dependencies:
   - python >=3.11,<3.13

--- a/snpio/docs/source/changelog.md
+++ b/snpio/docs/source/changelog.md
@@ -2,6 +2,17 @@
 
 This document outlines the changes made to the project with each release.
 
+## Unreleased
+
+### Release Engineering
+
+- Made Docker image tests block publication, included the repository resources
+  required by the complete test suite, and promoted warnings to errors through
+  the packaged pytest configuration.
+- Updated Docker and Conda setup actions for Node 24, removed deprecated action
+  inputs and the commercial default Conda channel, and added non-publishing
+  manual validation modes for released package artifacts.
+
 ## Version 1.7.0 (2026-07-23)
 
 ### Release Engineering

--- a/snpio/docs/source/changelog.rst
+++ b/snpio/docs/source/changelog.rst
@@ -4,6 +4,19 @@ Changelog
 
 This document outlines the changes made to the project with each release.
 
+Unreleased
+----------
+
+Release Engineering
+~~~~~~~~~~~~~~~~~~~
+
+- Made Docker image tests block publication, included the repository resources
+  required by the complete test suite, and promoted warnings to errors through
+  the packaged pytest configuration.
+- Updated Docker and Conda setup actions for Node 24, removed deprecated action
+  inputs and the commercial default Conda channel, and added non-publishing
+  manual validation modes for released package artifacts.
+
 Version 1.7.0 (2026-07-23)
 --------------------------
 


### PR DESCRIPTION
## Summary

Makes release-publisher validation authoritative after the 1.7.0 Docker logs
revealed that container tests failed during collection but were intentionally
ignored. The image now runs the complete warning-as-error suite as a blocking
build step, while Docker and Conda workflows use current warning-free actions
and support safe non-publishing validation reruns.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore / Documentation / Technical Debt

## Key Changes

- Copies `scripts/`, `multiqc_config.yml`, and `pyproject.toml` into the image
  so all tests collect and inherit warning-as-error policy.
- Installs `zsh` so the portable validation-runner test executes instead of
  being skipped, and removes the non-blocking pytest fallback.
- Removes Dockerfile warning sources, suppresses inappropriate root-pip output
  inside the isolated image, and avoids Conda default-channel/plugin notices.
- Upgrades QEMU, Buildx, Docker login, and setup-miniconda to their Node
  24-compatible action majors.
- Removes deprecated Buildx and Conda activation inputs and excludes the
  commercial `defaults` channel.
- Adds manual controls to rebuild Docker without re-uploading immutable PyPI
  files and to validate Conda packages without overwriting released artifacts.
- Adds an Unreleased changelog section for the post-1.7.0 publisher fixes.

## Verification & Testing

- Repository pre-push hook: 128 tests passed with warnings promoted to errors.
- Strict Sphinx build: succeeded with `-E -a -W --keep-going`.
- Publisher workflow YAML: parsed successfully.
- Embedded workflow shell blocks: passed `bash -n`.
- Conda environment policy: strict priority with no `defaults` channel.
- Staged diff: passed `git diff --cached --check`.
- Docker static check was unavailable locally because Docker Desktop was not
  running; the GitHub multi-architecture validation rerun is the authoritative
  image test.
