### PR TITLE
Fix release artifact validation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ __pycache__/
 *.egg-info/
 .build/
 dist/
+!dist/
+!dist/*.whl
 .cache/
 *.log
 *.tmp

--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -15,6 +15,13 @@ on:
       - "v*.*.*"
       - "conda-v*.*.*"
 
+env:
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: master
+  GIT_CONFIG_KEY_1: advice.detachedHead
+  GIT_CONFIG_VALUE_1: "false"
+
 # Define the jobs to be executed
 jobs:
   build-and-upload:
@@ -47,9 +54,13 @@ jobs:
         run: |
           conda install --yes --override-channels -c conda-forge \
             conda-build anaconda-client
+          set -o pipefail
+          # conda-build reports this false positive for single-output recipes:
+          # https://github.com/conda/conda-build/issues/5823
           conda-build recipe/ \
             --output-folder conda_build_artifacts \
-            --python ${{ matrix.python-version }} --no-test
+            --python ${{ matrix.python-version }} --no-test 2>&1 |
+            sed '/^WARNING: Number of parsed outputs does not match detected raw metadata blocks\./d'
 
       - name: Upload to Anaconda.org
         if: github.event_name == 'push' || inputs.upload_packages

--- a/.github/workflows/pypi-docker-publish.yml
+++ b/.github/workflows/pypi-docker-publish.yml
@@ -25,6 +25,13 @@ on:
     tags:
       - 'v*.*.*'  # Only run on semantic version tag pushes
 
+env:
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: master
+  GIT_CONFIG_KEY_1: advice.detachedHead
+  GIT_CONFIG_VALUE_1: "false"
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
@@ -69,7 +76,10 @@ jobs:
         run: rm -rf dist/
 
       - name: Build package
-        run: python -m build
+        run: |
+          python -m build
+          python -m twine check dist/*
+          python scripts/verify_distributions.py dist/*
 
       - name: Publish to TestPyPI
         if: github.event_name == 'push' || inputs.publish_python
@@ -114,6 +124,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: btmartin721/snpio
+          flavor: latest=false
           tags: |
             type=semver,pattern={{version}},value=${{ steps.extract_version.outputs.version }}
             type=raw,value=latest
@@ -127,6 +138,8 @@ jobs:
           push: true
           provenance: false  # Disable SBOM/attestation if unsupported on ARM
           builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            SNPIO_VERSION=${{ steps.extract_version.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -14,6 +14,13 @@ permissions:
   actions: write
   contents: write
 
+env:
+  GIT_CONFIG_COUNT: "2"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: master
+  GIT_CONFIG_KEY_1: advice.detachedHead
+  GIT_CONFIG_VALUE_1: "false"
+
 jobs:
   version-release:
     runs-on: ubuntu-latest
@@ -86,6 +93,7 @@ jobs:
         run: |
           python -m build
           python -m twine check dist/*
+          python scripts/verify_distributions.py dist/*
 
       - name: Push version commit and tag atomically
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Base image with Conda
 FROM continuumio/miniconda3
 
+ARG SNPIO_VERSION
+
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -41,10 +43,13 @@ RUN conda create --yes --solver classic --override-channels \
 
 ENV PATH=/opt/conda/envs/$CONDA_ENV/bin:$PATH
 
+COPY dist/snpio-${SNPIO_VERSION}-py3-none-any.whl /tmp/snpio.whl
+
 RUN conda run -n "$CONDA_ENV" python -m pip install --no-cache-dir \
-    snpio \
+    /tmp/snpio.whl \
     pytest \
     jupyterlab && \
+    rm /tmp/snpio.whl && \
     conda clean -afy
 
 # Create a non-root user and set home directory
@@ -61,7 +66,7 @@ WORKDIR /app
 COPY --chown=snpiouser:snpiouser tests/ tests/
 COPY --chown=snpiouser:snpiouser scripts/ scripts/
 COPY --chown=snpiouser:snpiouser scripts_and_notebooks/ scripts_and_notebooks/
-COPY --chown=snpiouser:snpiouser snpio/example_data/ example_data/
+COPY --chown=snpiouser:snpiouser snpio/example_data/ snpio/example_data/
 COPY --chown=snpiouser:snpiouser multiqc_config.yml pyproject.toml ./
 COPY --chown=snpiouser:snpiouser README.md docs/README.md
 COPY --chown=snpiouser:snpiouser scripts_and_notebooks/.bashrc_snpio /home/snpiouser/.bashrc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include LICENSE
 include pyproject.toml
+include snpio/img/snpio_logo.png
 
 recursive-include snpio *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ include = [
 ]
 
 [tool.setuptools.package-data]
+"snpio" = [
+    "img/snpio_logo.png",
+]
 "snpio.validation" = [
     "data/*.csv.gz",
     "data/*.json",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,9 @@ source:
 build:
   number: 0
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  # conda-build disables bytecode for noarch packages. Clearing the variable
+  # prevents setuptools from emitting warnings while preserving wheel contents.
+  script: "env -u PYTHONDONTWRITEBYTECODE {{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   build:

--- a/scripts/verify_distributions.py
+++ b/scripts/verify_distributions.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Verify that release distributions contain required runtime assets."""
+
+from __future__ import annotations
+
+import argparse
+import tarfile
+import zipfile
+from collections.abc import Iterable
+from pathlib import Path, PurePosixPath
+
+REQUIRED_PATHS = frozenset({"snpio/img/snpio_logo.png"})
+
+
+class DistributionVerificationError(ValueError):
+    """Raised when a distribution is unreadable or omits required files."""
+
+
+def _normalize_sdist_member(name: str) -> str:
+    """Remove the source-distribution root directory from a member path."""
+    parts = PurePosixPath(name).parts
+    return PurePosixPath(*parts[1:]).as_posix() if len(parts) > 1 else ""
+
+
+def distribution_members(distribution: Path) -> set[str]:
+    """Return normalized archive member paths for a wheel or source archive."""
+    distribution = distribution.resolve()
+    if not distribution.is_file():
+        raise DistributionVerificationError(
+            f"Distribution does not exist: {distribution}"
+        )
+
+    if distribution.suffix == ".whl":
+        with zipfile.ZipFile(distribution) as archive:
+            return {PurePosixPath(name).as_posix() for name in archive.namelist()}
+
+    if distribution.name.endswith((".tar.gz", ".tar.bz2")):
+        with tarfile.open(distribution, mode="r:*") as archive:
+            return {
+                _normalize_sdist_member(member.name)
+                for member in archive.getmembers()
+            }
+
+    raise DistributionVerificationError(
+        f"Unsupported distribution format: {distribution.name}"
+    )
+
+
+def verify_distribution(
+    distribution: Path,
+    required_paths: Iterable[str] = REQUIRED_PATHS,
+) -> None:
+    """Raise if a distribution omits any required runtime path."""
+    members = distribution_members(distribution)
+    missing = sorted(set(required_paths).difference(members))
+    if missing:
+        joined = ", ".join(missing)
+        raise DistributionVerificationError(
+            f"{distribution.name} is missing required runtime assets: {joined}"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "distributions",
+        nargs="+",
+        type=Path,
+        help="Wheel and source-distribution archives to inspect.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Verify all requested distributions."""
+    args = parse_args()
+    for distribution in args.distributions:
+        verify_distribution(distribution)
+        print(f"Verified runtime assets: {distribution}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/snpio/docs/dev/versioning.md
+++ b/snpio/docs/dev/versioning.md
@@ -107,10 +107,14 @@ BREAKING CHANGE: The minimum supported Python version is now 3.11.
   uses GitVersion's calculated semantic version.
 - Do **not** manually edit version files. `scripts/update_versions.py` updates
   `pyproject.toml`, `recipe/meta.yaml`, and `snpio/docs/source/conf.py`.
-- Tests, strict documentation, distribution builds, and Twine checks must pass
-  before the version commit and tag are pushed atomically.
+- Tests, strict documentation, distribution builds, Twine checks, and required
+  runtime-package-data checks must pass before the version commit and tag are
+  pushed atomically.
 - A GitHub Release is created from the tag, then the PyPI/Docker and Conda
   publishing workflows are explicitly dispatched at that tag.
+- The Docker image installs the wheel built by the same publishing run and
+  executes the complete unit-test suite against that installed artifact before
+  any image is pushed.
 
 ---
 
@@ -121,6 +125,8 @@ CI uses GitVersion to:
 - Compute the next version number
 - Update `pyproject.toml`, `recipe/meta.yaml`, and `snpio/docs/source/conf.py`
 - Run release validation before modifying `master`
+- Verify that every wheel and source distribution contains required runtime
+  assets, including the SNPio logo used by MultiQC reports
 - Atomically push the version commit and version tag (`vX.Y.Z`)
 - Create a GitHub Release with release notes
 - Dispatch the PyPI/Docker and Conda publishing workflows at the release tag

--- a/snpio/docs/source/changelog.md
+++ b/snpio/docs/source/changelog.md
@@ -4,6 +4,8 @@ This document outlines the changes made to the project with each release.
 
 ## Unreleased
 
+## Version 1.7.1 (2026-07-23)
+
 ### Release Engineering
 
 - Made Docker image tests block publication, included the repository resources
@@ -12,6 +14,14 @@ This document outlines the changes made to the project with each release.
 - Updated Docker and Conda setup actions for Node 24, removed deprecated action
   inputs and the commercial default Conda channel, and added non-publishing
   manual validation modes for released package artifacts.
+- Added required runtime-asset checks for wheels and source distributions,
+  packaged the SNPio MultiQC logo, and made Docker install the exact wheel
+  produced by its publishing run.
+- Corrected the Docker validation-data layout so the portable LD runner is
+  exercised rather than skipped or failed by missing repository resources.
+- Removed repository-controlled Conda and Git warning noise while retaining
+  strict failure propagation; the known single-output recipe warning from
+  `conda-build` is filtered narrowly pending its upstream fix.
 
 ## Version 1.7.0 (2026-07-23)
 

--- a/snpio/docs/source/changelog.rst
+++ b/snpio/docs/source/changelog.rst
@@ -7,6 +7,9 @@ This document outlines the changes made to the project with each release.
 Unreleased
 ----------
 
+Version 1.7.1 (2026-07-23)
+--------------------------
+
 Release Engineering
 ~~~~~~~~~~~~~~~~~~~
 
@@ -16,6 +19,14 @@ Release Engineering
 - Updated Docker and Conda setup actions for Node 24, removed deprecated action
   inputs and the commercial default Conda channel, and added non-publishing
   manual validation modes for released package artifacts.
+- Added required runtime-asset checks for wheels and source distributions,
+  packaged the SNPio MultiQC logo, and made Docker install the exact wheel
+  produced by its publishing run.
+- Corrected the Docker validation-data layout so the portable LD runner is
+  exercised rather than skipped or failed by missing repository resources.
+- Removed repository-controlled Conda and Git warning noise while retaining
+  strict failure propagation; the known single-output recipe warning from
+  ``conda-build`` is filtered narrowly pending its upstream fix.
 
 Version 1.7.0 (2026-07-23)
 --------------------------

--- a/tests/test_verify_distributions.py
+++ b/tests/test_verify_distributions.py
@@ -1,0 +1,57 @@
+"""Tests for release-distribution runtime-asset verification."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.verify_distributions import (
+    DistributionVerificationError,
+    verify_distribution,
+)
+
+LOGO_PATH = "snpio/img/snpio_logo.png"
+
+
+def test_verify_distribution_accepts_wheel_with_required_asset(
+    tmp_path: Path,
+) -> None:
+    """A wheel containing every required runtime asset should pass."""
+    wheel = tmp_path / "snpio-1.7.1-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, mode="w") as archive:
+        archive.writestr(LOGO_PATH, b"logo")
+
+    verify_distribution(wheel)
+
+
+def test_verify_distribution_accepts_sdist_with_required_asset(
+    tmp_path: Path,
+) -> None:
+    """An sdist root prefix should be removed before checking member paths."""
+    sdist = tmp_path / "snpio-1.7.1.tar.gz"
+    payload = b"logo"
+    info = tarfile.TarInfo(f"snpio-1.7.1/{LOGO_PATH}")
+    info.size = len(payload)
+    with tarfile.open(sdist, mode="w:gz") as archive:
+        archive.addfile(info, io.BytesIO(payload))
+
+    verify_distribution(sdist)
+
+
+def test_verify_distribution_rejects_missing_runtime_asset(
+    tmp_path: Path,
+) -> None:
+    """A distribution missing a required runtime asset should fail clearly."""
+    wheel = tmp_path / "snpio-1.7.1-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, mode="w") as archive:
+        archive.writestr("snpio/__init__.py", "")
+
+    with pytest.raises(
+        DistributionVerificationError,
+        match="snpio/img/snpio_logo.png",
+    ):
+        verify_distribution(wheel)


### PR DESCRIPTION
## Summary

Fix the post-release artifact defects exposed by strict Docker validation. The release archives now include and verify the MultiQC logo, Docker installs the exact wheel produced by the publishing run, and its validation data are copied to the repository-relative path expected by the portable LD runner. Conda publishing retains strict failure propagation while removing repository-controlled warning noise and narrowly filtering the documented upstream single-output recipe false positive.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore / Documentation / Technical Debt

## Key Changes

- Package `snpio/img/snpio_logo.png` in wheels and source distributions so installed MultiQC report generation can resolve its required runtime asset.
- Add a reusable distribution verifier and regression tests, and gate both release workflows on the verifier.
- Build Docker images from the exact wheel created in the same workflow instead of resolving `snpio` from PyPI.
- Restore the `/app/snpio/example_data` layout required by the portable LD validation runner and keep the full Docker test suite blocking.
- Remove duplicate Docker `latest` metadata and suppress Git initialization advice in release jobs.
- Clear `PYTHONDONTWRITEBYTECODE` only for the Conda wheel-build command to avoid setuptools noarch byte-compilation warnings.
- Filter only the known `conda-build` single-output false-positive warning documented in conda/conda-build#5823, with `pipefail` preserving all command failures.
- Document the corrected artifact contract and record the changes for v1.7.1.

## Verification & Testing

- `python -m pytest -q` — 131 passed with warnings promoted to errors.
- `python -m sphinx -E -a -W --keep-going -b html snpio/docs/source /tmp/snpio-artifact-docs-html` — strict build succeeded.
- Built clean wheel and sdist; `twine check` passed for both.
- `python scripts/verify_distributions.py /tmp/snpio-dist-artifact-fixes/*` — both archives contain required runtime assets.
- Installed the wheel into an isolated target and verified the packaged MultiQC logo exists and is non-empty.
- Parsed all GitHub workflow YAML and validated embedded Bash syntax.
- Pre-commit and pre-push hooks passed.

Codacy findings are intentionally non-blocking for this release, per maintainer direction.