### PR TITLE
Fix Docker wheel installation for v1.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,13 +43,13 @@ RUN conda create --yes --solver classic --override-channels \
 
 ENV PATH=/opt/conda/envs/$CONDA_ENV/bin:$PATH
 
-COPY dist/snpio-${SNPIO_VERSION}-py3-none-any.whl /tmp/snpio.whl
+COPY dist/snpio-${SNPIO_VERSION}-py3-none-any.whl /tmp/
 
 RUN conda run -n "$CONDA_ENV" python -m pip install --no-cache-dir \
-    /tmp/snpio.whl \
+    /tmp/snpio-${SNPIO_VERSION}-py3-none-any.whl \
     pytest \
     jupyterlab && \
-    rm /tmp/snpio.whl && \
+    rm /tmp/snpio-${SNPIO_VERSION}-py3-none-any.whl && \
     conda clean -afy
 
 # Create a non-root user and set home directory

--- a/snpio/docs/source/changelog.md
+++ b/snpio/docs/source/changelog.md
@@ -4,6 +4,14 @@ This document outlines the changes made to the project with each release.
 
 ## Unreleased
 
+## Version 1.7.2 (2026-07-23)
+
+### Release Engineering
+
+- Preserved the complete wheel filename inside Docker builds so pip can parse
+  its compatibility tags while installing the exact artifact produced by the
+  publishing workflow.
+
 ## Version 1.7.1 (2026-07-23)
 
 ### Release Engineering

--- a/snpio/docs/source/changelog.rst
+++ b/snpio/docs/source/changelog.rst
@@ -7,6 +7,16 @@ This document outlines the changes made to the project with each release.
 Unreleased
 ----------
 
+Version 1.7.2 (2026-07-23)
+--------------------------
+
+Release Engineering
+~~~~~~~~~~~~~~~~~~~
+
+- Preserved the complete wheel filename inside Docker builds so pip can parse
+  its compatibility tags while installing the exact artifact produced by the
+  publishing workflow.
+
 Version 1.7.1 (2026-07-23)
 --------------------------
 


### PR DESCRIPTION
## Summary

Preserve the complete locally built wheel filename inside the Docker build so pip can parse the wheel's Python, ABI, and platform tags. This restores the release pipeline's container installation and keeps Docker validation tied to the exact release artifact.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / Documentation / Technical Debt

## Key Changes

- Copy the versioned wheel into the image without renaming it to an invalid `snpio.whl` filename.
- Install and remove that exact versioned wheel path during the Docker build.
- Document the release-engineering correction in both changelog formats for v1.7.2.

## Verification & Testing

- Full local test suite: `131 passed`.
- Strict Sphinx build: `sphinx -E -a -W --keep-going` passed.
- Wheel build and `twine check` passed.
- Runtime distribution asset verification passed.
- Direct installation of the versioned wheel filename into a clean target directory passed.
- Pre-push pytest gate passed.

Codacy is intentionally non-blocking for this PR, per maintainer direction.