### PR TITLE
Prevent duplicate Conda noarch uploads

### DIFF
--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -63,7 +63,11 @@ jobs:
             sed '/^WARNING: Number of parsed outputs does not match detected raw metadata blocks\./d'
 
       - name: Upload to Anaconda.org
-        if: github.event_name == 'push' || inputs.upload_packages
+        # This is a noarch recipe, so both matrix legs produce the same archive.
+        # Build against both Python versions, but upload the shared artifact once.
+        if: >-
+          (github.event_name == 'push' || inputs.upload_packages) &&
+          matrix.python-version == '3.12'
         shell: bash -el {0}
         env:
           ANACONDA_API_TOKEN: ${{ secrets.SNPIO_UPLOAD_TOKEN }}

--- a/snpio/docs/source/changelog.md
+++ b/snpio/docs/source/changelog.md
@@ -4,6 +4,14 @@ This document outlines the changes made to the project with each release.
 
 ## Unreleased
 
+## Version 1.7.3 (2026-07-23)
+
+### Release Engineering
+
+- Kept Conda package builds on both supported Python versions while uploading
+  the shared `noarch` archive from only one matrix job, preventing concurrent
+  Anaconda.org uploads from racing on the same filename.
+
 ## Version 1.7.2 (2026-07-23)
 
 ### Release Engineering

--- a/snpio/docs/source/changelog.rst
+++ b/snpio/docs/source/changelog.rst
@@ -7,6 +7,16 @@ This document outlines the changes made to the project with each release.
 Unreleased
 ----------
 
+Version 1.7.3 (2026-07-23)
+--------------------------
+
+Release Engineering
+~~~~~~~~~~~~~~~~~~~
+
+- Kept Conda package builds on both supported Python versions while uploading
+  the shared ``noarch`` archive from only one matrix job, preventing concurrent
+  Anaconda.org uploads from racing on the same filename.
+
 Version 1.7.2 (2026-07-23)
 --------------------------
 


### PR DESCRIPTION
## Summary

Prevent the Conda publishing matrix from racing while uploading the same noarch package filename. Both supported Python versions still build the recipe, but only the Python 3.12 matrix leg uploads the shared artifact to Anaconda.org.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / Documentation / Technical Debt

## Key Changes

- Retain Conda builds against Python 3.11 and 3.12.
- Restrict Anaconda.org upload to one matrix leg for the shared `noarch/snpio-*-py_0.conda` artifact.
- Document the release-engineering correction in both changelog formats for v1.7.3.

## Verification & Testing

- Reproduced the publisher failure: Python 3.12 uploaded `snpio-1.7.2-py_0.conda`, then Python 3.11 received HTTP 409 for the identical filename.
- Full local test suite: `131 passed`.
- Strict Sphinx build: `sphinx -E -a -W --keep-going` passed.
- Workflow YAML parsing passed.
- `git diff --check` passed.
- Pre-push pytest gate passed.

Codacy is intentionally non-blocking for this PR, per maintainer direction.